### PR TITLE
(maint) Deploy to clojars

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,20 +1,18 @@
-(defn deploy-info
-  [url]
-  {:url url
-   :username :env/nexus_jenkins_username
-   :password :env/nexus_jenkins_password
-   :sign-releases false})
-
 (defproject puppetlabs/schema-tools "0.1.1-SNAPSHOT"
   :description "Tools for working with prismatic schema"
   :url "http://github.com/puppetlabs/clj-schema-tools"
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
+
   :pedantic? :abort
 
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [prismatic/schema "0.2.6"]]
 
-  :deploy-repositories [["releases" ~(deploy-info "http://nexus.delivery.puppetlabs.net/content/repositories/releases/")]
-                        ["snapshots" ~(deploy-info "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/")]]
+  :deploy-repositories [["releases" {:url "https://clojars.org/repo"
+                                     :username :env/clojars_jenkins_username
+                                     :password :env/clojars_jenkins_password
+                                     :sign-releases false}]]
 
   :lein-release {:scm :git
                  :deploy-via :lein-deploy}


### PR DESCRIPTION
The repo is already public and has an apache license file, so no reason to not push to clojars where it's easier to use.